### PR TITLE
Support rest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,27 @@ test selector for TestNG
 
 ## How to use
 
+### Using subset result
+
 ```
 # create subset list file
 $ launchable subset --target 30% maven src/test/java > subset.txt
 
 # set subset result file path to ENV
 $ export LAUNCHABLE_SUBSET_FILE_PATH=subset.txt
+
+# run tests
+$ mvn test
+```
+
+### Using rest result
+
+```
+# create rest list file
+$ launchable subset --target 30% --rest rest.txt maven src/test/java > subset.txt
+
+# set rest result file path to ENV
+$ export LAUNCHABLE_REST_FILE_PATH=rest.txt
 
 # run tests
 $ mvn test

--- a/src/main/java/com/launchableinc/testng/TestSelector.java
+++ b/src/main/java/com/launchableinc/testng/TestSelector.java
@@ -47,11 +47,14 @@ public class TestSelector implements IMethodInterceptor {
 				return methods;
 			}
 
+			LOGGER.info(String.format("Subset file (%s) is loaded", subsetFile));
 			if (subsetList.isEmpty()) {
 				LOGGER.warning(String.format("Subset file %s is empty. Please check your configuration",
 						subsetFile));
 			}
-		} else if (restFile != null){
+		}
+
+		if (restFile != null) {
 			try {
 				restList = readFromFile(restFile);
 			} catch (FileNotFoundException e) {
@@ -61,6 +64,7 @@ public class TestSelector implements IMethodInterceptor {
 				return methods;
 			}
 
+			LOGGER.info(String.format("Rest file (%s) is loaded", restFile));
 			if (restList.isEmpty()) {
 				LOGGER.warning(String.format("Rest file %s is empty. Please check your configuration",
 						restFile));
@@ -73,12 +77,13 @@ public class TestSelector implements IMethodInterceptor {
 			String className = m.getMethod().getTestClass().getName();
 			totalTestCount++;
 
-			if (restFile != null && restList.contains(className)) {
+			if (subsetFile != null && !subsetList.contains(className)) {
 				itr.remove();
 				filteredCount++;
+				continue;
 			}
 
-			if (subsetFile != null && !subsetList.contains(className)) {
+			if (restFile != null && restList.contains(className)) {
 				itr.remove();
 				filteredCount++;
 			}

--- a/src/main/java/com/launchableinc/testng/TestSelector.java
+++ b/src/main/java/com/launchableinc/testng/TestSelector.java
@@ -95,15 +95,13 @@ public class TestSelector implements IMethodInterceptor {
 		return methods;
 	}
 
-	private Set<String> readFromFile(String filePath ) throws FileNotFoundException {
+	private Set<String> readFromFile(String filePath) throws FileNotFoundException {
 		Set<String> list = new HashSet<>();
 		try (Scanner scanner = new Scanner(new FileReader(filePath))) {
 			while (scanner.hasNext()) {
 				String l = scanner.nextLine();
 				list.add(l);
 			}
-		} catch (Exception e) {
-			throw e;
 		}
 
 		return list;

--- a/src/main/java/com/launchableinc/testng/TestSelector.java
+++ b/src/main/java/com/launchableinc/testng/TestSelector.java
@@ -21,6 +21,8 @@ public class TestSelector implements IMethodInterceptor {
 
 	public static final String LAUNCHABLE_SUBSET_FILE = "LAUNCHABLE_SUBSET_FILE_PATH";
 
+	public static final String LAUNCHABLE_REST_FILE = "LAUNCHABLE_REST_FILE_PATH";
+
 	private static final Logger LOGGER = Logger.getLogger(TestSelector.class.getName());
 
 	/*package*/ int totalTestCount = 0;
@@ -30,19 +32,18 @@ public class TestSelector implements IMethodInterceptor {
 	@Override
 	public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext iTestContext) {
 		Set<String> subsetList = new HashSet<>();
+		Set<String> restList = new HashSet<>();
 
 		String subsetFile = System.getenv(LAUNCHABLE_SUBSET_FILE);
+		String restFile = System.getenv(LAUNCHABLE_REST_FILE);
+
 		if (subsetFile != null) {
-			try (Scanner scanner = new Scanner(new FileReader(subsetFile))) {
-				while (scanner.hasNext()) {
-					String l = scanner.nextLine();
-					subsetList.add(l);
-				}
+			try {
+				subsetList = readFromFile(subsetFile);
 			} catch (FileNotFoundException e) {
 				LOGGER.warning(String.format(
 						"Can not read subset file %s. Make sure to set subset result file path to %s",
 						subsetFile, LAUNCHABLE_SUBSET_FILE));
-
 				return methods;
 			}
 
@@ -50,18 +51,53 @@ public class TestSelector implements IMethodInterceptor {
 				LOGGER.warning(String.format("Subset file %s is empty. Please check your configuration",
 						subsetFile));
 			}
+		} else if (restFile != null){
+			try {
+				restList = readFromFile(restFile);
+			} catch (FileNotFoundException e) {
+				LOGGER.warning(String.format(
+						"Can not read rest file %s. Make sure to set rest result file path to %s",
+						restFile, LAUNCHABLE_REST_FILE));
+				return methods;
+			}
+
+			if (restList.isEmpty()) {
+				LOGGER.warning(String.format("Rest file %s is empty. Please check your configuration",
+						restFile));
+			}
 		}
 
 		Iterator<IMethodInstance> itr = methods.iterator();
 		while (itr.hasNext()) {
 			IMethodInstance m = itr.next();
+			String className = m.getMethod().getTestClass().getName();
 			totalTestCount++;
-			if (subsetFile != null && !subsetList.contains(m.getMethod().getTestClass().getName())) {
+
+			if (restFile != null && restList.contains(className)) {
+				itr.remove();
+				filteredCount++;
+			}
+
+			if (subsetFile != null && !subsetList.contains(className)) {
 				itr.remove();
 				filteredCount++;
 			}
 		}
 
 		return methods;
+	}
+
+	private Set<String> readFromFile(String filePath ) throws FileNotFoundException {
+		Set<String> list = new HashSet<>();
+		try (Scanner scanner = new Scanner(new FileReader(filePath))) {
+			while (scanner.hasNext()) {
+				String l = scanner.nextLine();
+				list.add(l);
+			}
+		} catch (Exception e) {
+			throw e;
+		}
+
+		return list;
 	}
 }

--- a/src/main/java/com/launchableinc/testng/TestSelector.java
+++ b/src/main/java/com/launchableinc/testng/TestSelector.java
@@ -37,12 +37,17 @@ public class TestSelector implements IMethodInterceptor {
 		String subsetFile = System.getenv(LAUNCHABLE_SUBSET_FILE);
 		String restFile = System.getenv(LAUNCHABLE_REST_FILE);
 
+		if (subsetFile != null && restFile != null) {
+			LOGGER.warning(String.format("ERROR: Cannot set subset file (%s) and rest file (%s) both. Make sure set only one side.", subsetFile, restFile));
+			return methods;
+		}
+
 		if (subsetFile != null) {
 			try {
 				subsetList = readFromFile(subsetFile);
 			} catch (FileNotFoundException e) {
 				LOGGER.warning(String.format(
-						"Can not read subset file %s. Make sure to set subset result file path to %s",
+						"Cannot read subset file %s. Make sure to set subset result file path to %s",
 						subsetFile, LAUNCHABLE_SUBSET_FILE));
 				return methods;
 			}
@@ -52,14 +57,12 @@ public class TestSelector implements IMethodInterceptor {
 				LOGGER.warning(String.format("Subset file %s is empty. Please check your configuration",
 						subsetFile));
 			}
-		}
-
-		if (restFile != null) {
+		} else if (restFile != null) {
 			try {
 				restList = readFromFile(restFile);
 			} catch (FileNotFoundException e) {
 				LOGGER.warning(String.format(
-						"Can not read rest file %s. Make sure to set rest result file path to %s",
+						"Cannot read rest file %s. Make sure to set rest result file path to %s",
 						restFile, LAUNCHABLE_REST_FILE));
 				return methods;
 			}

--- a/src/test/java/com/launchableinc/testng/TestSelectorTest.java
+++ b/src/test/java/com/launchableinc/testng/TestSelectorTest.java
@@ -139,8 +139,8 @@ public class TestSelectorTest {
 							Example3Test.class);
 			tng.addListener(selector);
 			tng.run();
-			assertEquals(selector.totalTestCount, 9);
-			assertEquals(selector.filteredCount, 5);
+			assertEquals(selector.totalTestCount, 0);
+			assertEquals(selector.filteredCount, 0);
 		});
 	}
 

--- a/src/test/java/com/launchableinc/testng/TestSelectorTest.java
+++ b/src/test/java/com/launchableinc/testng/TestSelectorTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.Map;
 import org.testng.Assert;
 import org.testng.TestNG;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;


### PR DESCRIPTION
`launchable subset` command support `--rest` option. However this launchableinc/testng library can't use it now.
So, I supported `LAUNCHABLE_REST_FILE_PATH` for exclusion