### PR TITLE
add opens configuration for module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.launchableinc</groupId>
   <artifactId>launchable-testng</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0</version>
 
   <name>launchable-testng</name>
   <url>https://launchableinc.com/</url>
@@ -15,7 +15,7 @@
     <connection>scm:git:git@github.com:launchableinc/testng.git</connection>
     <url>scm:git:git@github.com:launchableinc/testng.git</url>
     <developerConnection>scm:git:git@github.com:launchableinc/testng.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>launchable-testng-1.1.0</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,9 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.1</version>
+          <configuration>
+            <argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.launchableinc</groupId>
   <artifactId>launchable-testng</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1-SNAPSHOT</version>
 
   <name>launchable-testng</name>
   <url>https://launchableinc.com/</url>
@@ -15,7 +15,7 @@
     <connection>scm:git:git@github.com:launchableinc/testng.git</connection>
     <url>scm:git:git@github.com:launchableinc/testng.git</url>
     <developerConnection>scm:git:git@github.com:launchableinc/testng.git</developerConnection>
-    <tag>launchable-testng-1.1.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>


### PR DESCRIPTION
From Java9, [module](https://www.oracle.com/corporate/features/understanding-java-9-modules.html) was introduced. Since then, cannot access without allowing by module, even if it was reflection.

When java version is over 9, these errors will happen

```
[ERROR] Tests run: 15, Failures: 5, Errors: 0, Skipped: 0, Time elapsed: 0.455 s <<< FAILURE! - in TestSuite
[ERROR] intercept_set_empty_subset_file(com.launchableinc.testng.TestSelectorTest)  Time elapsed: 0.034 s  <<< FAILURE!
java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @1e4ddaa2
        at com.launchableinc.testng.TestSelectorTest.intercept_set_empty_subset_file(TestSelectorTest.java:119)

[ERROR] intercept_set_no_available_test_path(com.launchableinc.testng.TestSelectorTest)  Time elapsed: 0.006 s  <<< FAILURE!
java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @1e4ddaa2
        at com.launchableinc.testng.TestSelectorTest.intercept_set_no_available_test_path(TestSelectorTest.java:83)

[ERROR] intercept_set_not_exists_subset_file_path(com.launchableinc.testng.TestSelectorTest)  Time elapsed: 0.001 s  <<< FAILURE!
java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @1e4ddaa2
        at com.launchableinc.testng.TestSelectorTest.intercept_set_not_exists_subset_file_path(TestSelectorTest.java:100)

[ERROR] intercept_set_subset_list(com.launchableinc.testng.TestSelectorTest)  Time elapsed: 0.001 s  <<< FAILURE!
java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @1e4ddaa2
        at com.launchableinc.testng.TestSelectorTest.intercept_set_subset_list(TestSelectorTest.java:42)

[ERROR] intercept_set_subset_multiple_list(com.launchableinc.testng.TestSelectorTest)  Time elapsed: 0.001 s  <<< FAILURE!
java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @1e4ddaa2
        at com.launchableinc.testng.TestSelectorTest.intercept_set_subset_multiple_list(TestSelectorTest.java:63)
``` 

However, if we set `--add-opens` option, can access it. 
So, I added this configuration