### PR TITLE
provide constructor for tests and not to use system-lambda

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,6 @@
       <artifactId>testng</artifactId>
       <version>6.0</version>
     </dependency>
-    <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-lambda</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/com/launchableinc/testng/TestSelectorTest.java
+++ b/src/test/java/com/launchableinc/testng/TestSelectorTest.java
@@ -6,30 +6,19 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import org.testng.TestNG;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 
 public class TestSelectorTest {
-
-
-	@BeforeTest
-	public void before() {
-		assertNull(System.getenv(TestSelector.LAUNCHABLE_SUBSET_FILE));
-		assertNull(System.getenv(TestSelector.LAUNCHABLE_REST_FILE));
-	}
 
 	@Test
 	public void not_intercept() {
 		TestSelector selector = new TestSelector();
-
-		TestNG tng = createTests("not-set-lists", Example1Test.class, Example2Test.class,
-				Example3Test.class);
+		TestNG tng =
+				createTests("not-set-lists", Example1Test.class, Example2Test.class, Example3Test.class);
 		tng.addListener(selector);
 		tng.run();
 		assertEquals(selector.totalTestCount, 9);
@@ -44,15 +33,14 @@ public class TestSelectorTest {
 		Files.write(file.toPath(),
 				"com.launchableinc.testng.Example1Test".getBytes(StandardCharsets.UTF_8));
 
-		withEnvironmentVariable(TestSelector.LAUNCHABLE_SUBSET_FILE, file.getPath()).execute(() -> {
-			TestSelector selector = new TestSelector();
-			TestNG tng = createTests("set-subset-list", Example1Test.class, Example2Test.class,
-					Example3Test.class);
-			tng.addListener(selector);
-			tng.run();
-			assertEquals(selector.totalTestCount, 9);
-			assertEquals(selector.filteredCount, 7);
-		});
+
+		TestSelector selector = new TestSelector(file, null);
+		TestNG tng =
+				createTests("set-subset-list", Example1Test.class, Example2Test.class, Example3Test.class);
+		tng.addListener(selector);
+		tng.run();
+		assertEquals(selector.totalTestCount, 9);
+		assertEquals(selector.filteredCount, 7);
 	}
 
 	@Test
@@ -63,15 +51,14 @@ public class TestSelectorTest {
 		Files.write(file.toPath(),
 				"com.launchableinc.testng.Example1Test".getBytes(StandardCharsets.UTF_8));
 
-		withEnvironmentVariable(TestSelector.LAUNCHABLE_REST_FILE, file.getPath()).execute(() -> {
-			TestSelector selector = new TestSelector();
-			TestNG tng = createTests("set-rest-list", Example1Test.class, Example2Test.class,
-					Example3Test.class);
-			tng.addListener(selector);
-			tng.run();
-			assertEquals(selector.totalTestCount, 9);
-			assertEquals(selector.filteredCount, 2);
-		});
+		TestSelector selector = new TestSelector(null, file);
+		TestNG tng =
+				createTests("set-rest-list", Example1Test.class, Example2Test.class, Example3Test.class);
+		tng.addListener(selector);
+		tng.run();
+		assertEquals(selector.totalTestCount, 9);
+		assertEquals(selector.filteredCount, 2);
+
 	}
 
 	@Test
@@ -82,16 +69,14 @@ public class TestSelectorTest {
 				"com.launchableinc.testng.Example1Test\ncom.launchableinc.testng.Example2Test"
 						.getBytes(StandardCharsets.UTF_8));
 
-		withEnvironmentVariable(TestSelector.LAUNCHABLE_SUBSET_FILE, file.getPath()).execute(() -> {
-			TestSelector selector = new TestSelector();
-			TestNG tng =
-					createTests("set-subset-multiple-list", Example1Test.class, Example2Test.class,
-							Example3Test.class);
-			tng.addListener(selector);
-			tng.run();
-			assertEquals(selector.totalTestCount, 9);
-			assertEquals(selector.filteredCount, 3);
-		});
+		TestSelector selector = new TestSelector(file, null);
+		TestNG tng = createTests("set-subset-multiple-list", Example1Test.class, Example2Test.class,
+				Example3Test.class);
+		tng.addListener(selector);
+		tng.run();
+		assertEquals(selector.totalTestCount, 9);
+		assertEquals(selector.filteredCount, 3);
+
 	}
 
 	@Test
@@ -102,16 +87,14 @@ public class TestSelectorTest {
 				"com.launchableinc.testng.Example1Test\ncom.launchableinc.testng.Example2Test"
 						.getBytes(StandardCharsets.UTF_8));
 
-		withEnvironmentVariable(TestSelector.LAUNCHABLE_REST_FILE, file.getPath()).execute(() -> {
-			TestSelector selector = new TestSelector();
-			TestNG tng =
-					createTests("set-rest-multiple-list", Example1Test.class, Example2Test.class,
-							Example3Test.class);
-			tng.addListener(selector);
-			tng.run();
-			assertEquals(selector.totalTestCount, 9);
-			assertEquals(selector.filteredCount, 6);
-		});
+		TestSelector selector = new TestSelector(null, file);
+		TestNG tng = createTests("set-rest-multiple-list", Example1Test.class, Example2Test.class,
+				Example3Test.class);
+		tng.addListener(selector);
+		tng.run();
+		assertEquals(selector.totalTestCount, 9);
+		assertEquals(selector.filteredCount, 6);
+
 	}
 
 	@Test
@@ -119,8 +102,7 @@ public class TestSelectorTest {
 		File subset = File.createTempFile("subset-", ".txt");
 		subset.deleteOnExit();
 		Files.write(subset.toPath(),
-				"com.launchableinc.testng.Example2Test"
-						.getBytes(StandardCharsets.UTF_8));
+				"com.launchableinc.testng.Example2Test".getBytes(StandardCharsets.UTF_8));
 
 		File rest = File.createTempFile("rest-", ".txt");
 		rest.deleteOnExit();
@@ -128,16 +110,13 @@ public class TestSelectorTest {
 				"com.launchableinc.testng.Example1Test\ncom.launchableinc.testng.Example3Test"
 						.getBytes(StandardCharsets.UTF_8));
 
-		withEnvironmentVariable(TestSelector.LAUNCHABLE_SUBSET_FILE, subset.getPath()).and(TestSelector.LAUNCHABLE_REST_FILE, rest.getPath()).execute(() -> {
-			TestSelector selector = new TestSelector();
-			TestNG tng =
-					createTests("set-subset-and-rest-list", Example1Test.class, Example2Test.class,
-							Example3Test.class);
-			tng.addListener(selector);
-			tng.run();
-			assertEquals(selector.totalTestCount, 0);
-			assertEquals(selector.filteredCount, 0);
-		});
+		TestSelector selector = new TestSelector(subset, rest);
+		TestNG tng = createTests("set-subset-and-rest-list", Example1Test.class, Example2Test.class,
+				Example3Test.class);
+		tng.addListener(selector);
+		tng.run();
+		assertEquals(selector.totalTestCount, 0);
+		assertEquals(selector.filteredCount, 0);
 	}
 
 	@Test
@@ -148,33 +127,25 @@ public class TestSelectorTest {
 				"com.launchableinc.testng.Sample1Test\ncom.launchableinc.testng.Sample2Test\ncom.launchableinc.testok.Example1Test"
 						.getBytes(StandardCharsets.UTF_8));
 
-		assertNull(System.getenv(TestSelector.LAUNCHABLE_SUBSET_FILE));
-		withEnvironmentVariable(TestSelector.LAUNCHABLE_SUBSET_FILE, file.getPath()).execute(() -> {
-					TestSelector selector = new TestSelector();
-					TestNG tng =
-							createTests("set-subset-list", Example1Test.class, Example2Test.class,
-									Example3Test.class);
-					tng.addListener(selector);
-					tng.run();
-					assertEquals(selector.totalTestCount, 9);
-					assertEquals(selector.filteredCount, 9);
-		});
-
-
+		TestSelector selector = new TestSelector(file, null);
+		TestNG tng =
+				createTests("set-subset-list", Example1Test.class, Example2Test.class, Example3Test.class);
+		tng.addListener(selector);
+		tng.run();
+		assertEquals(selector.totalTestCount, 9);
+		assertEquals(selector.filteredCount, 9);
 	}
 
 	@Test
 	public void intercept_set_not_exists_subset_file_path() throws Exception {
-		withEnvironmentVariable(TestSelector.LAUNCHABLE_SUBSET_FILE, "invalid_subset_file.txt").execute(() -> {
-			TestSelector selector = new TestSelector();
-			TestNG tng = createTests("invalid_subset_file.txt", Example1Test.class, Example2Test.class,
-					Example3Test.class);
-			tng.addListener(selector);
-			tng.run();
-			// If subset file doesn't exist, selector will return the inputted methods as is.
-			assertEquals(selector.totalTestCount, 0);
-			assertEquals(selector.filteredCount, 0);
-		});
+		TestSelector selector = new TestSelector(new File("invalid_subset_file.txt"), null);
+		TestNG tng = createTests("invalid_subset_file.txt", Example1Test.class, Example2Test.class,
+				Example3Test.class);
+		tng.addListener(selector);
+		tng.run();
+		// If subset file doesn't exist, selector will return the inputted methods as is.
+		assertEquals(selector.totalTestCount, 0);
+		assertEquals(selector.filteredCount, 0);
 	}
 
 	@Test
@@ -183,16 +154,14 @@ public class TestSelectorTest {
 		file.deleteOnExit();
 		Files.write(file.toPath(), "".getBytes(StandardCharsets.UTF_8));
 
-		withEnvironmentVariable(TestSelector.LAUNCHABLE_SUBSET_FILE, file.getPath()).execute(() -> {
-			TestSelector selector = new TestSelector();
-			TestNG tng = createTests("invalid_subset_file.txt", Example1Test.class, Example2Test.class,
-					Example3Test.class);
-			tng.addListener(selector);
-			tng.run();
+		TestSelector selector = new TestSelector(file, null);
+		TestNG tng = createTests("invalid_subset_file.txt", Example1Test.class, Example2Test.class,
+				Example3Test.class);
+		tng.addListener(selector);
+		tng.run();
 
-			assertEquals(selector.totalTestCount, 9);
-			assertEquals(selector.filteredCount, 9);
-		});
+		assertEquals(selector.totalTestCount, 9);
+		assertEquals(selector.filteredCount, 9);
 	}
 
 	private TestNG createTests(String suiteName, Class<?>... testClasses) {


### PR DESCRIPTION
Because system-lambda accesses the private field of java.util package used by reflection. 
However, from Java 9, it doesn't allow it. So, I stop using it.