### PR TITLE
Bumped up to TestNG 6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.0</version>
+      <version>6.2</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/launchableinc/testng/TestSelector.java
+++ b/src/main/java/com/launchableinc/testng/TestSelector.java
@@ -1,21 +1,22 @@
 package com.launchableinc.testng;
 
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.util.HashSet;
-import java.util.Scanner;
-import java.util.Set;
-import java.util.logging.Logger;
 import org.kohsuke.MetaInfServices;
 import org.testng.IMethodInstance;
 import org.testng.IMethodInterceptor;
 import org.testng.ITestContext;
 import org.testng.ITestNGListener;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.logging.Logger;
 
 @MetaInfServices(ITestNGListener.class)
 public class TestSelector implements IMethodInterceptor {
@@ -29,10 +30,6 @@ public class TestSelector implements IMethodInterceptor {
 	private final File subsetFile;
 
 	private final File restFile;
-
-	/* package */ int totalTestCount = 0;
-
-	/* package */ int filteredCount = 0;
 
 	/* package */ public TestSelector(File subsetFile, File restFile) {
 		this.subsetFile = subsetFile;
@@ -91,21 +88,21 @@ public class TestSelector implements IMethodInterceptor {
 			}
 		}
 
+		// we are going to mutate the list, so we need to make a copy.
+		// TestNG does appear to give us a read-only list sometimes.
+		methods = new ArrayList<>(methods);
 		Iterator<IMethodInstance> itr = methods.iterator();
 		while (itr.hasNext()) {
 			IMethodInstance m = itr.next();
 			String className = m.getMethod().getTestClass().getName();
-			totalTestCount++;
 
 			if (subsetFile != null && !subsetList.contains(className)) {
 				itr.remove();
-				filteredCount++;
 				continue;
 			}
 
 			if (restFile != null && restList.contains(className)) {
 				itr.remove();
-				filteredCount++;
 			}
 		}
 

--- a/src/test/java/com/launchableinc/testng/TestSelectorTest.java
+++ b/src/test/java/com/launchableinc/testng/TestSelectorTest.java
@@ -1,172 +1,131 @@
 package com.launchableinc.testng;
 
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.Collections;
+import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import static java.util.Arrays.asList;
 import static org.testng.Assert.assertEquals;
 
 public class TestSelectorTest {
+	private TestListenerAdapter testCounter;
 
 	@Test
 	public void not_intercept() {
 		TestSelector selector = new TestSelector();
-		TestNG tng =
-				createTests("not-set-lists", Example1Test.class, Example2Test.class, Example3Test.class);
-		tng.addListener(selector);
-		tng.run();
-		assertEquals(selector.totalTestCount, 9);
-		assertEquals(selector.filteredCount, 0);
+		runTests("not-set-lists", selector);
+		assertTestCounts(9);
 	}
 
 	@Test
 	public void intercept_set_subset_list() throws Exception {
-		File file = File.createTempFile("subset-", ".txt");
-		file.deleteOnExit();
+		File file = createListFile("subset-", "com.launchableinc.testng.Example1Test");
 
-		Files.write(file.toPath(),
-				"com.launchableinc.testng.Example1Test".getBytes(StandardCharsets.UTF_8));
-
-
-		TestSelector selector = new TestSelector(file, null);
-		TestNG tng =
-				createTests("set-subset-list", Example1Test.class, Example2Test.class, Example3Test.class);
-		tng.addListener(selector);
-		tng.run();
-		assertEquals(selector.totalTestCount, 9);
-		assertEquals(selector.filteredCount, 7);
+		runTests("set-subset-list", new TestSelector(file, null));
+		assertTestCounts(2);
 	}
 
 	@Test
 	public void intercept_set_rest_list() throws Exception {
-		File file = File.createTempFile("rest-", ".txt");
-		file.deleteOnExit();
+		File file = createListFile("rest-", "com.launchableinc.testng.Example1Test");
 
-		Files.write(file.toPath(),
-				"com.launchableinc.testng.Example1Test".getBytes(StandardCharsets.UTF_8));
-
-		TestSelector selector = new TestSelector(null, file);
-		TestNG tng =
-				createTests("set-rest-list", Example1Test.class, Example2Test.class, Example3Test.class);
-		tng.addListener(selector);
-		tng.run();
-		assertEquals(selector.totalTestCount, 9);
-		assertEquals(selector.filteredCount, 2);
+		runTests("set-rest-list", new TestSelector(null, file));
+		assertTestCounts(7);
 
 	}
 
 	@Test
 	public void intercept_set_multiple_subset_list() throws Exception {
-		File file = File.createTempFile("subset-", ".txt");
-		file.deleteOnExit();
-		Files.write(file.toPath(),
-				"com.launchableinc.testng.Example1Test\ncom.launchableinc.testng.Example2Test"
-						.getBytes(StandardCharsets.UTF_8));
+		File file = createListFile("subset-", "com.launchableinc.testng.Example1Test\ncom.launchableinc.testng.Example2Test");
 
-		TestSelector selector = new TestSelector(file, null);
-		TestNG tng = createTests("set-subset-multiple-list", Example1Test.class, Example2Test.class,
-				Example3Test.class);
-		tng.addListener(selector);
-		tng.run();
-		assertEquals(selector.totalTestCount, 9);
-		assertEquals(selector.filteredCount, 3);
-
+		runTests("set-subset-multiple-list", new TestSelector(file, null));
+		assertTestCounts(6);
 	}
 
 	@Test
 	public void intercept_set_multiple_rest_list() throws Exception {
-		File file = File.createTempFile("rest-", ".txt");
-		file.deleteOnExit();
-		Files.write(file.toPath(),
-				"com.launchableinc.testng.Example1Test\ncom.launchableinc.testng.Example2Test"
-						.getBytes(StandardCharsets.UTF_8));
+		File file = createListFile("rest-", "com.launchableinc.testng.Example1Test\ncom.launchableinc.testng.Example2Test");
 
-		TestSelector selector = new TestSelector(null, file);
-		TestNG tng = createTests("set-rest-multiple-list", Example1Test.class, Example2Test.class,
-				Example3Test.class);
-		tng.addListener(selector);
-		tng.run();
-		assertEquals(selector.totalTestCount, 9);
-		assertEquals(selector.filteredCount, 6);
-
+		runTests("set-rest-multiple-list", new TestSelector(null, file));
+		assertTestCounts(3);
 	}
 
 	@Test
 	public void intercept_set_subset_and_rest_list() throws Exception {
-		File subset = File.createTempFile("subset-", ".txt");
-		subset.deleteOnExit();
-		Files.write(subset.toPath(),
-				"com.launchableinc.testng.Example2Test".getBytes(StandardCharsets.UTF_8));
+		File subset = createListFile("subset-", "com.launchableinc.testng.Example2Test");
+		File rest = createListFile("rest-", "com.launchableinc.testng.Example1Test\ncom.launchableinc.testng.Example3Test");
 
-		File rest = File.createTempFile("rest-", ".txt");
-		rest.deleteOnExit();
-		Files.write(rest.toPath(),
-				"com.launchableinc.testng.Example1Test\ncom.launchableinc.testng.Example3Test"
-						.getBytes(StandardCharsets.UTF_8));
-
-		TestSelector selector = new TestSelector(subset, rest);
-		TestNG tng = createTests("set-subset-and-rest-list", Example1Test.class, Example2Test.class,
-				Example3Test.class);
-		tng.addListener(selector);
-		tng.run();
-		assertEquals(selector.totalTestCount, 0);
-		assertEquals(selector.filteredCount, 0);
+		runTests("set-subset-and-rest-list", new TestSelector(subset, rest));
+		// both are specified, so we refrain from doing subsetting at all.
+		assertTestCounts(9);
 	}
 
 	@Test
 	public void intercept_set_no_available_test_path() throws Exception {
-		File file = File.createTempFile("subset-", ".txt");
-		file.deleteOnExit();
-		Files.write(file.toPath(),
-				"com.launchableinc.testng.Sample1Test\ncom.launchableinc.testng.Sample2Test\ncom.launchableinc.testok.Example1Test"
-						.getBytes(StandardCharsets.UTF_8));
+		File file = createListFile("subset-", "com.launchableinc.testng.Sample1Test\ncom.launchableinc.testng.Sample2Test\ncom.launchableinc.testok.Example1Test");
 
-		TestSelector selector = new TestSelector(file, null);
-		TestNG tng =
-				createTests("set-subset-list", Example1Test.class, Example2Test.class, Example3Test.class);
-		tng.addListener(selector);
-		tng.run();
-		assertEquals(selector.totalTestCount, 9);
-		assertEquals(selector.filteredCount, 9);
+		runTests("set-subset-list", new TestSelector(file, null));
+		assertTestCounts(0);
 	}
 
 	@Test
-	public void intercept_set_not_exists_subset_file_path() throws Exception {
-		TestSelector selector = new TestSelector(new File("invalid_subset_file.txt"), null);
-		TestNG tng = createTests("invalid_subset_file.txt", Example1Test.class, Example2Test.class,
-				Example3Test.class);
-		tng.addListener(selector);
-		tng.run();
+	public void intercept_set_not_exists_subset_file_path() {
+		runTests("invalid_subset_file.txt", new TestSelector(new File("invalid_subset_file.txt"), null));
 		// If subset file doesn't exist, selector will return the inputted methods as is.
-		assertEquals(selector.totalTestCount, 0);
-		assertEquals(selector.filteredCount, 0);
+		assertTestCounts(9);
 	}
 
 	@Test
 	public void intercept_set_empty_subset_file() throws Exception {
-		File file = File.createTempFile("subset-", ".txt");
-		file.deleteOnExit();
-		Files.write(file.toPath(), "".getBytes(StandardCharsets.UTF_8));
+		File file = createListFile("subset-", "");
 
-		TestSelector selector = new TestSelector(file, null);
-		TestNG tng = createTests("invalid_subset_file.txt", Example1Test.class, Example2Test.class,
-				Example3Test.class);
-		tng.addListener(selector);
-		tng.run();
-
-		assertEquals(selector.totalTestCount, 9);
-		assertEquals(selector.filteredCount, 9);
+		runTests("invalid_subset_file.txt", new TestSelector(file, null));
+		assertTestCounts(0);
 	}
 
-	private TestNG createTests(String suiteName, Class<?>... testClasses) {
+
+
+	@BeforeMethod
+	public void setup() {
+		testCounter = new TestListenerAdapter();
+	}
+
+	private void assertTestCounts(int total) {
+		assertEquals(testCounter.getPassedTests().size(), total);
+		assertEquals(testCounter.getFailedTests().size(), 0);
+
+		// this might sound confusing, but methods filtered out by IMethodInterceptor do not count skipped
+		// as far as TestNG is concerned. It's as if those tests were not even considered in the first place.
+		assertEquals(testCounter.getSkippedTests().size(), 0);
+	}
+
+	private File createListFile(String prefix, String x) throws IOException {
+		File file = File.createTempFile(prefix, ".txt");
+		file.deleteOnExit();
+
+		Files.write(file.toPath(), x.getBytes(StandardCharsets.UTF_8));
+		return file;
+	}
+
+
+	private void runTests(String suiteName, TestSelector selector) {
 		XmlSuite suite = createXmlSuite(suiteName);
-		for (Class<?> testClass : testClasses) {
+		for (Class<?> testClass : asList(Example1Test.class, Example2Test.class,
+			Example3Test.class)) {
 			createXmlTest(suite, testClass.getName(), testClass);
 		}
 
@@ -174,7 +133,17 @@ public class TestSelectorTest {
 		result.setUseDefaultListeners(false);
 		result.setVerbose(0);
 		result.setXmlSuites(Collections.singletonList(suite));
-		return result;
+		// this prevents TestNG from discovering TestSelector via service loader, to avoid double filtering
+		// TestNG doesn't support multiple method interceptor (at least as of testing).
+		result.setServiceLoaderClassLoader(new URLClassLoader(new URL[0]) {
+			@Override
+			public Enumeration<URL> getResources(String name) {
+				return Collections.emptyEnumeration();
+			}
+		});
+		result.addListener(testCounter);
+		result.addListener(selector);
+		result.run();
 	}
 
 	private XmlSuite createXmlSuite(String suiteName) {


### PR DESCRIPTION
For service loader lookup for test selector to work, customers need to use TestNG 6.2 or later, which contains this crucial bug fix: https://github.com/testng-team/testng/commit/f38bbfab2b620883b38039baac48585efd057bf3

So I decided that it'd be prudent for us to test this library with that version.

The new version of TestNG uncovered a bug in our code, where we were modifying the list given to us. TestNG apparently doesn't expect this in some cases, so we needed to make a defensive copy.

With this change, I also needed to update tests, in part because TestNG is now passing the same methods multiple times. That means previous naive counting approach doesn't work anymore.

I also refactored the test code somewhat to make it more DRY.